### PR TITLE
Potential fix for code scanning alert no. 66: Database query built from user-controlled sources

### DIFF
--- a/server.js
+++ b/server.js
@@ -128,7 +128,7 @@ app.post('/send-money', async (req, res) => {
         }
         // Find sender and receiver by usernames
         const sender = await User.findOne({ username: senderUsername });
-        const receiver = await User.findOne({ username: receiverUsername });
+        const receiver = await User.findOne({ username: { $eq: receiverUsername } });
         if (!sender || !receiver) {
             return res.status(404).send('Sender or receiver not found');
         }


### PR DESCRIPTION
Potential fix for [https://github.com/ohitsmeMohit/LoginAzure/security/code-scanning/66](https://github.com/ohitsmeMohit/LoginAzure/security/code-scanning/66)

To fix this, we need to ensure that the `receiverUsername` is treated strictly as a string, not an object, before using it inside the query. There are two idiomatic ways to do this with MongoDB and Mongoose:

1. Use the `$eq` operator: Replace `{ username: receiverUsername }` with `{ username: { $eq: receiverUsername } }` - this ensures MongoDB interprets the input as a literal value only.
2. Alternatively, **validate** that `receiverUsername` is a string (and e.g. matches a username format) before using it.

The fix should be minimal and not change the endpoint’s functionality: thus, the best fix is to use the `$eq` operator in the query on line 131.

Only the affected line (and some context) should be edited, keeping everything else as is.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
