### PR TITLE
Potential fix for code scanning alert no. 54: Missing CSRF middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "pip": "^0.0.1",
     "send": "^1.2.0",
     "serve-static": "^2.2.0",
-    "express-rate-limit": "^8.1.0"
+    "express-rate-limit": "^8.1.0",
+    "lusca": "^1.7.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.34.0",

--- a/server.js
+++ b/server.js
@@ -4,11 +4,13 @@ const path = require('path');
 const mongoose = require('mongoose');
 const cookieParser = require('cookie-parser');
 const rateLimit = require('express-rate-limit');
+const lusca = require('lusca');
 const app = express();
 
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
 app.use(cookieParser());
+app.use(lusca.csrf());
 app.use(express.static(path.join(__dirname, 'public')));
 const mongostring = "mongodb://mk-mongo:6MACyvG8WvxuJlN4aVQOSGS3a5Gs3O6YFxrYFDmYI8k5Tezt29q2iL8dWcOIuzK9VwaJmAWT8FjlACDbJPL3Ig%3D%3D@mk-mongo.mongo.cosmos.azure.com:10255/?ssl=true&retrywrites=false&maxIdleTimeMS=120000&appName=@mk-mongo@"
 


### PR DESCRIPTION
Potential fix for [https://github.com/ohitsmeMohit/LoginAzure/security/code-scanning/54](https://github.com/ohitsmeMohit/LoginAzure/security/code-scanning/54)

To fix the missing CSRF protection, you should add CSRF middleware to your Express app. The most straightforward method is to use a library like `lusca` or `csurf`. Here, the typical, recommended approach is to install the `lusca` package and add its `csrf()` middleware **after** session and cookie parsing, but **before** any state-changing routes.

In this code, you need to:
- Import `lusca` at the top of the file.
- Insert `app.use(lusca.csrf());` right after cookie parsing (`app.use(cookieParser());`) and **before** any routes that require CSRF protection (e.g., `/send-money` POST).
- Make sure the order of middlewares is correct: body parser → cookie parser → lusca CSRF → static files/routes.
- Ensure that you expose the CSRF token to the front end for form requests, if necessary. (As this is backend code, this mainly means the backend will now expect requests to send a valid `_csrf` token for POST/PUT/DELETE requests.)

No changes to the business logic itself are needed. All edits are to `server.js`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
